### PR TITLE
Support for the CeCILL 2.1 license

### DIFF
--- a/src/spdx.rs
+++ b/src/spdx.rs
@@ -88,6 +88,7 @@ pub const LICENSES: &'static [&'static str] = &[
     "CECILL-1.0",
     "CECILL-1.1",
     "CECILL-2.0",
+    "CECILL-2.1",
     "CECILL-B",
     "CECILL-C",
     "CNRI-Python",


### PR DESCRIPTION
The CeCILL Free Software License Agreement v2.1 is OSI an approved license and listed as so in [spdx.org](https://spdx.org/licenses/). However only the versions 1.0, 1.1 and 2.0 were accepted. This change adds the new version.
