### PR TITLE
Add UPL-1.0 identifier from https://spdx.org/licenses/

### DIFF
--- a/src/spdx.rs
+++ b/src/spdx.rs
@@ -287,6 +287,7 @@ pub const LICENSES: &'static [&'static str] = &[
     "TMate",
     "TORQUE-1.1",
     "TOSL",
+    "UPL-1.0",
     "Unicode-TOU",
     "Unlicense",
     "VOSTROM",


### PR DESCRIPTION
This PR simply adds the UPL-1.0 identifier from https://spdx.org/licenses/ (needed for things like https://github.com/softdevteam/cactus).

Notice that before and after this PR there is a failing test:

```
---- tests::compound_license stdout ----
        thread 'tests::compound_license' panicked at 'assertion failed: super::validate_license_expr("GPL-3.0+ WITH Classpath-exception-2.0 OR MIT AND AAL").is_ok()', src/lib.rs:86
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

but I don't think this PR is the right place to fix that.