### PR TITLE
Cargo.toml: Replace '/' with 'OR' in 'license'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,6 @@
 name = "license-exprs"
 version = "1.3.0"
 authors = ["Without Boats <woboats@gmail.com>"]
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 description = "Validate SPDX 2.0 license expressions."
 repository = "https://github.com/withoutboats/license-exprs"


### PR DESCRIPTION
Catch up with the recommendations from rust-lang/cargo#4898, which deprecated '/' in favor of vanilla SPDX license expressions.

See #14 for previous discussion and sign-offs from most existing contributors.

@nodakai, I'd still like to hear from you about your licensing intentions with #8 (and your open PRs).

Fixes #14.