### PR TITLE
src/spdx.rs: Bump to SDPX License List 3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "license-exprs"
 version = "1.3.0"
 authors = ["Without Boats <woboats@gmail.com>"]
 license = "Apache-2.0 OR MIT"
-description = "Validate SPDX 2.1 license expressions using SPDX License List 3.0 identifiers."
+description = "Validate SPDX 2.1 license expressions using SPDX License List 3.1 identifiers."
 repository = "https://github.com/withoutboats/license-exprs"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # license-exprs
 
-This crate validates [SPDX 2.1 license expressions][SPDX-license-expressions] using short identifiers from the [SPDX 3.0 License List][SPDX-license-list].
+This crate validates [SPDX 2.1 license expressions][SPDX-license-expressions] using short identifiers from the [SPDX 3.1 License List][SPDX-license-list].
 
 ## Limitations
 
@@ -14,4 +14,4 @@ Licensed under the [Apache License, Version 2.0][Apache-2.0] ([`LICENSE-APACHE`]
 [MIT]: https://opensource.org/licenses/MIT
 [parens]: https://github.com/rust-lang-nursery/license-exprs/issues/3
 [SPDX-license-expressions]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
-[SPDX-license-list]: https://github.com/spdx/license-list-data/tree/v3.0
+[SPDX-license-list]: https://github.com/spdx/license-list-data/tree/v3.1

--- a/src/spdx.rs
+++ b/src/spdx.rs
@@ -7,7 +7,7 @@
  * cargo run --example fetch-license-list-from-spdx v3.0 > spdx.rs
  */
 
-pub const VERSION: &'static str = "3.0";
+pub const VERSION: &'static str = "3.1";
 
 pub const LICENSES: &'static [&'static str] = &[
     "0BSD",
@@ -19,6 +19,8 @@ pub const LICENSES: &'static [&'static str] = &[
     "AFL-2.1",
     "AFL-3.0",
     "AGPL-1.0",
+    "AGPL-1.0-only",
+    "AGPL-1.0-or-later",
     "AGPL-3.0",
     "AGPL-3.0-only",
     "AGPL-3.0-or-later",
@@ -222,7 +224,9 @@ pub const LICENSES: &'static [&'static str] = &[
     "LiLiQ-R-1.1",
     "LiLiQ-Rplus-1.1",
     "Libpng",
+    "Linux-OpenIB",
     "MIT",
+    "MIT-0",
     "MIT-CMU",
     "MIT-advertising",
     "MIT-enna",
@@ -395,11 +399,13 @@ pub const EXCEPTIONS: &'static [&'static str] = &[
     "Font-exception-2.0",
     "GCC-exception-2.0",
     "GCC-exception-3.1",
+    "LLVM-exception",
     "LZMA-exception",
     "Libtool-exception",
     "Linux-syscall-note",
     "Nokia-Qt-exception-1.1",
     "OCCT-exception-1.0",
+    "OpenJDK-assembly-exception-1.0",
     "Qwt-exception-1.0",
     "WxWindows-exception-3.1",
     "eCos-exception-2.0",


### PR DESCRIPTION
Generated with:

```console
$ cargo run --example fetch-license-list-from-spdx v3.1 >spdx.rs
$ mv spdx.rs src/
$ emacs Cargo.toml README.md  # manual bumps
```

This builds on #17; only the tip commit is new to this PR.  I'll give it a bit of extra cook time after #17 lands, so no rush on review ;).