### PR TITLE
Use failure for error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ repository = "https://github.com/withoutboats/license-exprs"
 name = "fetch-license-list-from-spdx"
 path = "examples/fetch.rs"
 
+[dependencies]
+failure = { version = "0.1.1", features = ["derive"] }
+
 [dev-dependencies]
 reqwest = "0.8"
 serde_json = "1"
-error-chain = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,76 +1,69 @@
-use std::error::Error;
+#[macro_use]
+extern crate failure;
+
 use std::fmt;
+
 mod spdx;
 
 use self::LicenseExpr::*;
 
-#[derive(Debug, Clone, Copy)]
-pub enum LicenseExpr<'a> {
-    License(&'a str),
-    Exception(&'a str),
-    And, Or, With, 
+#[derive(Clone, Debug)]
+pub enum LicenseExpr {
+    License(String),
+    Exception(String),
+    And,
+    Or,
+    With,
 }
 
-impl<'a> fmt::Display for LicenseExpr<'a> {
+impl fmt::Display for LicenseExpr {
     fn fmt(&self, format: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
             With => format.write_str("WITH"),
-            And  => format.write_str("AND"),
-            Or   => format.write_str("OR"),
-            License(info) | Exception(info) => format.write_str(info),
+            And => format.write_str("AND"),
+            Or => format.write_str("OR"),
+            License(ref info) | Exception(ref info) => format.write_str(info),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ParseError<'a> {
-    UnknownLicenseId(&'a str),
-    InvalidStructure(LicenseExpr<'a>)
-}
-
-impl<'a> fmt::Display for ParseError<'a> {
-    fn fmt(&self, format: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            ParseError::UnknownLicenseId(info)
-                => format.write_fmt(format_args!("{}: {}", self.description(), info)),
-            ParseError::InvalidStructure(info)
-                => format.write_fmt(format_args!("{}: {}", self.description(), info)),
-        }
-    }
-}
-
-impl<'a> Error for ParseError<'a> {
-    fn description(&self) -> &str {
-        match *self {
-            ParseError::UnknownLicenseId(_) => "unknown license or other term",
-            ParseError::InvalidStructure(_) => "invalid license expression",
-        }
-    }
+#[derive(Clone, Debug, Fail)]
+pub enum ParseError {
+    #[fail(display = "unknown license or other term: {}", _0)]
+    UnknownLicenseId(String),
+    #[fail(display = "invalid license expression: {}", _0)]
+    InvalidStructure(LicenseExpr),
 }
 
 pub fn validate_license_expr(license_expr: &str) -> Result<(), ParseError> {
-    license_expr.split_whitespace().map(|word| match word {
-        "AND"   => Ok(And),
-        "OR"    => Ok(Or),
-        "WITH"  => Ok(With),
-        _ if spdx::LICENSES.binary_search(&word.trim_right_matches('+')).is_ok()
-                => Ok(License(word)),
-        _ if spdx::EXCEPTIONS.binary_search(&word).is_ok()
-                => Ok(Exception(word)),
-        _       => Err(ParseError::UnknownLicenseId(word))
-    }).fold(Ok(Or), |prev, word| match (prev, word) {
-        (err @ Err(_), _) | (_, err @ Err(_)) => err,
-        (Ok(License(_)), Ok(With))
+    license_expr
+        .split_whitespace()
+        .map(|word| match word {
+            "AND" => Ok(And),
+            "OR" => Ok(Or),
+            "WITH" => Ok(With),
+            _ if spdx::LICENSES
+                .binary_search(&word.trim_right_matches('+'))
+                .is_ok() =>
+            {
+                Ok(License(word.to_string()))
+            }
+            _ if spdx::EXCEPTIONS.binary_search(&word).is_ok() => Ok(Exception(word.to_string())),
+            _ => Err(ParseError::UnknownLicenseId(word.to_string())),
+        })
+        .fold(Ok(Or), |prev, word| match (prev, word.clone()) {
+            (err @ Err(_), _) | (_, err @ Err(_)) => err,
+            (Ok(License(_)), Ok(With))
             | (Ok(License(_)), Ok(And))
             | (Ok(License(_)), Ok(Or))
             | (Ok(Exception(_)), Ok(And))
             | (Ok(Exception(_)), Ok(Or))
             | (Ok(And), Ok(License(_)))
             | (Ok(Or), Ok(License(_)))
-            | (Ok(With), Ok(Exception(_)))
-            => word,
-        _ => Err(ParseError::InvalidStructure(word.unwrap()))
-    }).and(Ok(()))
+            | (Ok(With), Ok(Exception(_))) => word,
+            _ => Err(ParseError::InvalidStructure(word.unwrap())),
+        })
+        .and(Ok(()))
 }
 
 pub fn license_version() -> &'static str {
@@ -79,30 +72,31 @@ pub fn license_version() -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use super::validate_license_expr;
 
     #[test]
     fn single_license() {
-        assert!(super::validate_license_expr("MIT").is_ok());
+        assert!(validate_license_expr("MIT").is_ok());
     }
 
     #[test]
     fn compound_license() {
-        assert!(super::validate_license_expr("GPL-3.0+ WITH Classpath-exception-2.0 OR MIT AND AAL")
-                .is_ok());
+        assert!(
+            validate_license_expr("GPL-3.0+ WITH Classpath-exception-2.0 OR MIT AND AAL").is_ok()
+        );
     }
 
     #[test]
     fn fails_invalid_license() {
-        assert!(super::validate_license_expr("asdfghjkl").is_err());
-        assert!(super::validate_license_expr("MIT AND qwerty").is_err())
+        assert!(validate_license_expr("asdfghjkl").is_err());
+        assert!(validate_license_expr("MIT AND qwerty").is_err())
     }
 
     #[test]
     fn fails_incorrect_structure() {
-        assert!(super::validate_license_expr("WITH").is_err());
-        assert!(super::validate_license_expr("MIT OR WITH").is_err());
-        assert!(super::validate_license_expr("MIT AND Classpath-exception-2.0").is_err());
-        assert!(super::validate_license_expr("Classpath-exception-2.0").is_err());
+        assert!(validate_license_expr("WITH").is_err());
+        assert!(validate_license_expr("MIT OR WITH").is_err());
+        assert!(validate_license_expr("MIT AND Classpath-exception-2.0").is_err());
+        assert!(validate_license_expr("Classpath-exception-2.0").is_err());
     }
-
 }


### PR DESCRIPTION
### Added

* Add dependency on `failure` crate.

### Changed

* Use `String` instead of `&'a str` in `ParseError` and `LicenseExpr` to satisfy `'static` bound on `Fail` trait.
* Eliminate use of `error_chain` in `fetch-license-from-spdx` example; use `failure::Error` instead.
* Run `rustfmt` on codebase.