### PR TITLE
.mailmap: Consolidate authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Rodolphe Breard <rodolphe@what.tf> <breard-r@users.noreply.github.com>
+Wim Looman <wim@nemo157.com>
+Without Boats <woboats@gmail.com>
+Without Boats <woboats@gmail.com> <lee@libertad.ucsd.edu>


### PR DESCRIPTION
This gives us a single entry in Git's author logs, consolidating authors and committers who have used multiple names and/or emails.

The format is described in `git-shortlog(1)`.