### PR TITLE
Cargo.toml: Bump to v1.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "license-exprs"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Without Boats <woboats@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 description = "Validate SPDX 2.1 license expressions using SPDX License List 3.1 identifiers."


### PR DESCRIPTION
Changes since v1.3.0:

* Updated SPDX License List to 3.1 (#9, #11, #17, #19, #24).
* Updated SPDX License Expression reference from 2.0 to 2.1 (#8).
* Document our license-list version, parens issue, and license (#16, #17).
* Add Travis CI configuration (#22).
* Add additional test cases (#25).
* `.mailmap`: Consolidate authors (#26).

I'll give this at least a week to cook, and then merge, tag, and push a release to crates.io.

Fixes #18.
Fixes #27.