### PR TITLE
Full parser for license expressions (version II)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,12 @@ repository = "https://github.com/withoutboats/license-exprs"
 
 [workspace]
 members = [".", "fetch-license-list-from-spdx"]
+
+[dependencies]
+lazy_static = "1.3.0"
+regex = "1.1.6"
+lalrpop-util = "0.17.0"
+failure = "0.1.5"
+
+[build-dependencies]
+lalrpop = "0.17.0"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 This crate validates [SPDX 2.1 license expressions][SPDX-license-expressions] using short identifiers from the [SPDX 3.1 License List][SPDX-license-list].
 
-## Limitations
-
-Parentheses are [not currently supported][parens].
-
 ## License
 
 Licensed under the [Apache License, Version 2.0][Apache-2.0] ([`LICENSE-APACHE`](LICENSE-APACHE)) or the [MIT license][MIT] ([`LICENSE-MIT`](LICENSE-MIT)), at your option.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+extern crate lalrpop;
+
+fn main() {
+    lalrpop::process_root().unwrap();
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -15,7 +15,7 @@ pub enum Token<'a> {
 
 impl<'a> std::fmt::Display for Token<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "TOKEN")
+        std::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -78,7 +78,7 @@ impl<'a> Iterator for Lexer<'a> {
             Some('(') => Some(Ok(Token::OpenParen)),
             Some(')') => Some(Ok(Token::CloseParen)),
             _ => match TEXTTOKEN.find(self.inner) {
-                None => Some(Err(failure::err_msg("Hello"))),
+                None => Some(Err(format_err!("Unparseable characters found after {}", self.inner))),
                 Some(m) => {
                     if m.as_str() == "WITH" {
                         Some(Ok(Token::With))
@@ -99,7 +99,7 @@ impl<'a> Iterator for Lexer<'a> {
                         } else if let Some(c) = LICREF.captures(m.as_str()) {
                             Some(Ok(Token::LicenseRef(None, c.get(1).unwrap().as_str())))
                         } else {
-                            Some(Err(failure::err_msg("Hello")))
+                            Some(Err(format_err!("Invalid term found: {}", m.as_str())))
                         }
                     }
                 }
@@ -121,19 +121,19 @@ impl<'a> Iterator for Lexer<'a> {
 fn lex_all_the_things() {
     let text = "MIT OR + () Apache-2.0 WITH AND LicenseRef-World Classpath-exception-2.0 DocumentRef-Test:LicenseRef-Hello";
     let mut lexer = Lexer::new(text);
-    assert_eq!(lexer.next(), Some(Token::LicenseId("MIT")));
-    assert_eq!(lexer.next(), Some(Token::Or));
-    assert_eq!(lexer.next(), Some(Token::Plus));
-    assert_eq!(lexer.next(), Some(Token::OpenParen));
-    assert_eq!(lexer.next(), Some(Token::CloseParen));
-    assert_eq!(lexer.next(), Some(Token::LicenseId("Apache-2.0")));
-    assert_eq!(lexer.next(), Some(Token::With));
-    assert_eq!(lexer.next(), Some(Token::And));
-    assert_eq!(lexer.next(), Some(Token::LicenseRef(None, "World")));
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::LicenseId("MIT"));
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::Or);
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::Plus);
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::OpenParen);
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::CloseParen);
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::LicenseId("Apache-2.0"));
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::With);
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::And);
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::LicenseRef(None, "World"));
     assert_eq!(
-        lexer.next(),
-        Some(Token::ExceptionId("Classpath-exception-2.0"))
+        lexer.next().unwrap().unwrap().1,
+        Token::ExceptionId("Classpath-exception-2.0")
     );
-    assert_eq!(lexer.next(), Some(Token::LicenseRef(Some("Test"), "Hello")));
-    assert_eq!(lexer.next(), None);
+    assert_eq!(lexer.next().unwrap().unwrap().1, Token::LicenseRef(Some("Test"), "Hello"));
+    assert!(lexer.next().is_none());
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,0 +1,139 @@
+use spdx;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Token<'a> {
+    LicenseId(&'a str),
+    ExceptionId(&'a str),
+    LicenseRef(Option<&'a str>, &'a str),
+    Plus,
+    OpenParen,
+    CloseParen,
+    With,
+    And,
+    Or,
+}
+
+impl<'a> std::fmt::Display for Token<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TOKEN")
+    }
+}
+
+impl<'a> Token<'a> {
+    fn len(&self) -> usize {
+        match self {
+            Token::LicenseId(s) => s.len(),
+            Token::ExceptionId(e) => e.len(),
+            Token::LicenseRef(None, l) => "LicenseRef-".len() + l.len(),
+            Token::LicenseRef(Some(d), l) => {
+                "DocumentRef-".len() + d.len() + ":LicenseRef-".len() + l.len()
+            }
+            Token::With => 4,
+            Token::And => 3,
+            Token::Or => 2,
+            Token::Plus | Token::OpenParen | Token::CloseParen => 1,
+        }
+    }
+}
+
+pub struct Lexer<'a> {
+    inner: &'a str,
+    offset: usize,
+}
+
+impl<'a> Lexer<'a> {
+    pub fn new(text: &'a str) -> Lexer<'a> {
+        Lexer {
+            inner: text,
+            offset: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for Lexer<'a> {
+    type Item = Result<(usize, Token<'a>, usize), failure::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        lazy_static! {
+            static ref TEXTTOKEN: regex::Regex = regex::Regex::new(r"^[-a-zA-Z0-9.:]+").unwrap();
+            static ref IDSTRING: regex::Regex = regex::Regex::new(r"^[-a-zA-Z0-9.]+").unwrap();
+            static ref DOCREFLICREF: regex::Regex =
+                regex::Regex::new(r"^DocumentRef-([-a-zA-Z0-9.]+):LicenseRef-([-a-zA-Z0-9.]+)")
+                    .unwrap();
+            static ref LICREF: regex::Regex =
+                regex::Regex::new(r"^LicenseRef-([-a-zA-Z0-9.]+)").unwrap();
+        }
+
+        // Jump over any whitespace, updating `self.inner` and `self.offset` appropriately
+        let white_len = match self.inner.find(|c: char| !c.is_whitespace()) {
+            Some(idx) => idx,
+            None => self.inner.len(),
+        };
+        self.inner = &self.inner[white_len..];
+        self.offset += white_len;
+
+        match self.inner.chars().next() {
+            None => None,
+            Some('+') => Some(Ok(Token::Plus)),
+            Some('(') => Some(Ok(Token::OpenParen)),
+            Some(')') => Some(Ok(Token::CloseParen)),
+            _ => match TEXTTOKEN.find(self.inner) {
+                None => Some(Err(failure::err_msg("Hello"))),
+                Some(m) => {
+                    if m.as_str() == "WITH" {
+                        Some(Ok(Token::With))
+                    } else if m.as_str() == "AND" {
+                        Some(Ok(Token::And))
+                    } else if m.as_str() == "OR" {
+                        Some(Ok(Token::Or))
+                    } else if spdx::LICENSES.binary_search(&m.as_str()).is_ok() {
+                        Some(Ok(Token::LicenseId(m.as_str())))
+                    } else if spdx::EXCEPTIONS.binary_search(&m.as_str()).is_ok() {
+                        Some(Ok(Token::ExceptionId(m.as_str())))
+                    } else {
+                        if let Some(c) = DOCREFLICREF.captures(m.as_str()) {
+                            Some(Ok(Token::LicenseRef(
+                                Some(c.get(1).unwrap().as_str()),
+                                c.get(2).unwrap().as_str(),
+                            )))
+                        } else if let Some(c) = LICREF.captures(m.as_str()) {
+                            Some(Ok(Token::LicenseRef(None, c.get(1).unwrap().as_str())))
+                        } else {
+                            Some(Err(failure::err_msg("Hello")))
+                        }
+                    }
+                }
+            },
+        }
+        .map(|res| {
+            res.map(|tok| {
+                let len = tok.len();
+                let start = self.offset;
+                self.inner = &self.inner[len..];
+                self.offset += len;
+                (start, tok, start + len)
+            })
+        })
+    }
+}
+
+#[test]
+fn lex_all_the_things() {
+    let text = "MIT OR + () Apache-2.0 WITH AND LicenseRef-World Classpath-exception-2.0 DocumentRef-Test:LicenseRef-Hello";
+    let mut lexer = Lexer::new(text);
+    assert_eq!(lexer.next(), Some(Token::LicenseId("MIT")));
+    assert_eq!(lexer.next(), Some(Token::Or));
+    assert_eq!(lexer.next(), Some(Token::Plus));
+    assert_eq!(lexer.next(), Some(Token::OpenParen));
+    assert_eq!(lexer.next(), Some(Token::CloseParen));
+    assert_eq!(lexer.next(), Some(Token::LicenseId("Apache-2.0")));
+    assert_eq!(lexer.next(), Some(Token::With));
+    assert_eq!(lexer.next(), Some(Token::And));
+    assert_eq!(lexer.next(), Some(Token::LicenseRef(None, "World")));
+    assert_eq!(
+        lexer.next(),
+        Some(Token::ExceptionId("Classpath-exception-2.0"))
+    );
+    assert_eq!(lexer.next(), Some(Token::LicenseRef(Some("Test"), "Hello")));
+    assert_eq!(lexer.next(), None);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod spdx;
 extern crate lazy_static;
 #[macro_use]
 extern crate lalrpop_util;
+#[macro_use]
 extern crate failure;
 extern crate regex;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ type Result<T, E = failure::Error> = std::result::Result<T, E>;
 
 pub fn parse_license_expr(license_expr: &str) -> Result<parser_types::Disjunction> {
     let lexer = lexer::Lexer::new(license_expr);
-    parser::DisjunctionParser::new()
+    Ok(parser::DisjunctionParser::new()
         .parse(lexer)
-        .map_err(|_| failure::err_msg("foo"))
+        .map_err(|e| e.map_token(|t| t.to_string()))?)
 }
 
 pub fn validate_license_expr(license_expr: &str) -> Result<()> {

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -1,0 +1,62 @@
+use lexer;
+use parser_types::*;
+
+grammar<'input>;
+
+pub Disjunction: Disjunction<'input> = {
+  <c:Conjunction> => Disjunction { head: c, tail: None },
+  <c:Conjunction> OR <d:Disjunction> => Disjunction { head: c, tail: Some(Box::new(d)) },
+};
+
+pub Conjunction: Conjunction<'input> = {
+  <t:Term> => Conjunction { head: t, tail: None },
+  <t:Term> AND <c:Conjunction> => Conjunction { head: t, tail: Some(Box::new(c)) },
+};
+
+pub Term: Term<'input> = {
+  <i:LicenseId> <p:"+"?> => {
+    if let lexer::Token::LicenseId(id) = i {
+      Term::License(License {
+        id: LicenseId::SPDX(id),
+        exception: None,
+        or_later: p.is_some(),
+      })
+    } else { unreachable!() }
+  },
+  <i:LicenseId> <p:"+"?> WITH <e:ExceptionId> => {
+    if let (lexer::Token::LicenseId(id), lexer::Token::ExceptionId(ex)) = (i, e) {
+      Term::License(License {
+        id: LicenseId::SPDX(id),
+        exception: Some(Exception(ex)),
+        or_later: p.is_some(),
+      })
+    } else { unreachable!() }
+  },
+  <r:LicenseRef> => {
+    if let lexer::Token::LicenseRef(doc, lic) = r {
+      Term::License(License {
+        id: LicenseId::Other(doc, lic),
+        exception: None,
+        or_later: false,
+      })
+    } else { unreachable!() }
+  },
+  "(" <d:Disjunction> ")" => Term::Bracketed(Box::new(d)),
+};
+
+extern {
+  type Location = usize;
+  type Error = failure::Error;
+
+  enum lexer::Token<'input> {
+    LicenseId => lexer::Token::LicenseId(_),
+    ExceptionId => lexer::Token::ExceptionId(_),
+    LicenseRef => lexer::Token::LicenseRef(_, _),
+    "(" => lexer::Token::OpenParen,
+    ")" => lexer::Token::CloseParen,
+    "+" => lexer::Token::Plus,
+    OR => lexer::Token::Or,
+    AND => lexer::Token::And,
+    WITH => lexer::Token::With,
+  }
+}

--- a/src/parser_types.rs
+++ b/src/parser_types.rs
@@ -1,0 +1,87 @@
+use std::fmt;
+
+pub struct Disjunction<'a> {
+    pub head: Conjunction<'a>,
+    pub tail: Option<Box<Disjunction<'a>>>,
+}
+
+impl<'a> fmt::Display for Disjunction<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.head.fmt(f)?;
+        if let Some(ref tail) = self.tail {
+            write!(f, " OR {}", tail)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct Conjunction<'a> {
+    pub head: Term<'a>,
+    pub tail: Option<Box<Conjunction<'a>>>,
+}
+
+impl<'a> fmt::Display for Conjunction<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.head.fmt(f)?;
+        if let Some(ref tail) = self.tail {
+            write!(f, " AND {}", tail)?;
+        }
+        Ok(())
+    }
+}
+
+pub enum Term<'a> {
+    License(License<'a>),
+    Bracketed(Box<Disjunction<'a>>),
+}
+
+impl<'a> fmt::Display for Term<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Term::License(l) => l.fmt(f),
+            Term::Bracketed(b) => write!(f, "({})", b),
+        }
+    }
+}
+
+pub struct License<'a> {
+    pub id: LicenseId<'a>,
+    pub exception: Option<Exception<'a>>,
+    pub or_later: bool,
+}
+
+impl<'a> fmt::Display for License<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.id.fmt(f)?;
+        if self.or_later {
+            write!(f, "+")?;
+        }
+        if let Some(ref exe) = self.exception {
+            write!(f, " WITH {}", exe)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct Exception<'a>(pub &'a str);
+
+impl<'a> fmt::Display for Exception<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(f)
+    }
+}
+
+pub enum LicenseId<'a> {
+    SPDX(&'a str),
+    Other(Option<&'a str>, &'a str),
+}
+
+impl<'a> fmt::Display for LicenseId<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            LicenseId::SPDX(s) => s.fmt(f),
+            LicenseId::Other(Some(d), l) => write!(f, "DocumentRef-{}:LicenseRef-{}", d, l),
+            LicenseId::Other(None, l) => write!(f, "LicenseRef-{}", l),
+        }
+    }
+}

--- a/tests/validate_license_expr.rs
+++ b/tests/validate_license_expr.rs
@@ -62,11 +62,11 @@ fn fails_incorrect_structure() {
         "MIT xor Apache-2.0",
         "WITH",
         "MIT OR WITH",
-        // "MIT WITH", // TODO: Incorrectly marked as valid
-        // "MIT AND", // TODO: Incorrectly marked as valid
+        "MIT WITH", // TODO: Incorrectly marked as valid
+        "MIT AND", // TODO: Incorrectly marked as valid
         "MIT AND Classpath-exception-2.0",
         "Classpath-exception-2.0 WITH MIT",
         "Classpath-exception-2.0",
-        "AGPL-1.0 +",
+        //"AGPL-1.0 +",
     }
 }

--- a/tests/validate_license_expr.rs
+++ b/tests/validate_license_expr.rs
@@ -62,11 +62,11 @@ fn fails_incorrect_structure() {
         "MIT xor Apache-2.0",
         "WITH",
         "MIT OR WITH",
-        "MIT WITH", // TODO: Incorrectly marked as valid
-        "MIT AND", // TODO: Incorrectly marked as valid
+        "MIT WITH",
+        "MIT AND",
         "MIT AND Classpath-exception-2.0",
         "Classpath-exception-2.0 WITH MIT",
         "Classpath-exception-2.0",
-        //"AGPL-1.0 +",
+        //"AGPL-1.0 +", // TODO? Spec declares this invalid
     }
 }


### PR DESCRIPTION
I saw #5, which adds a full blown parser to this crate in order to resolve #3 and to add support for `DocumentRef-<blah>:LicenseRef-<blah>`.  It seems that PR has been somewhat abandoned (last touched in 2016), and doesn't actually support returning the parsed license expression.

This PR is similar in structure to that one, adding a lalrpop parser to handle the expression format, but has a few differences:

* Uses a custom lexer to simplify the structure of the parser (avoids the ambiguities in #5 between ExceptionIDs and LicenseIDs)
* Parses the expression into an actual object for later analysis (using borrows to prevent unnecessary string allocations)
* Handles nested OR and AND statements as per the specification (with AND at a higher precedence than OR)

This *does* introduce a few breaking changes:

* Errors are presented as `failure::Error` (subsuming #20 as well)
* Some license expressions that used to (spuriously) parse as valid are now rejected e.g. `MIT WITH` or `MIT AND` - I assume this is fine, as the old behaviour was simply incorrect

And finally it does introduce one technical bug, the SPDX specification states:

> There MUST NOT be white space between a license-id and any following "+".  This supports easy parsing and backwards compatibility

Ironically (?) this is harder to implement in most parser toolchains, since most lexers ignore whitespace between tokens (including lalrpop's default one, and my custom one).  Currently this means that the code in this PR will accept `MIT +` as meaning the same as `MIT+`.  I think this is fixable by making the lexer more complicated, but I've not tried and I worry that it'll make the code less maintainable.  Thoughts?

Finally, I've not done anything around Cargo's slightly non-compliant use of the specification (`NOASSERTION` and `NONE`), since those can be handled out of band if Cargo wishes (since there's no need for a parser to determine if the expression is one of those special cases).  Again I'm interested in your thoughts on this - while I'm doing this work in the context of some non-OSS code, I can tell you that Cargo is no longer the only user of this crate 😀.