### PR TITLE
Update deps (reqwests, error-chain), syntax deprecations

### DIFF
--- a/fetch-license-list-from-spdx/Cargo.toml
+++ b/fetch-license-list-from-spdx/Cargo.toml
@@ -5,6 +5,6 @@ authors = []
 publish = false
 
 [dependencies]
-reqwest = "0.8"
+reqwest = "0.9"
 serde_json = "1"
-error-chain = "0.11"
+error-chain = "0.12"

--- a/fetch-license-list-from-spdx/src/main.rs
+++ b/fetch-license-list-from-spdx/src/main.rs
@@ -14,7 +14,7 @@ use serde_json::{Value, map};
 // We'll put our errors in a `errors` module
 mod errors {
     // Create the Error, ErrorKind, ResultExt, and Result types
-    #[allow(unused_doc_comment)]
+    #[allow(unused_doc_comments)]
     error_chain!{
         // Automatic conversions between this error chain and other
         // error types not defined by the `error_chain!`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn validate_license_expr(license_expr: &str) -> Result<(), ParseError> {
         "AND"   => Ok(And),
         "OR"    => Ok(Or),
         "WITH"  => Ok(With),
-        _ if spdx::LICENSES.binary_search(&word.trim_right_matches('+')).is_ok()
+        _ if spdx::LICENSES.binary_search(&word.trim_end_matches('+')).is_ok()
                 => Ok(License(word)),
         _ if spdx::EXCEPTIONS.binary_search(&word).is_ok()
                 => Ok(Exception(word)),


### PR DESCRIPTION
This primarily extends OpenSSL support to v1.1.1, and also fixes a few warnings about active or impending deprecations. Of course some of these might get overwritten by one of the other PRs but that assumes they land, and until then these seem like relatively uncontroversial updates.

This commit compiles (and tests) without warnings on rustc v1.37.0.